### PR TITLE
Sorting events by closer

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ layout: base
                     <span class="slider round"></span>
                 </label>
             </div>
-            {% assign sorted = site.data.events | sort: 'date','last' | reverse %}
+            {% assign sorted = site.data.events | sort: 'date','last' %}
             {% for event in sorted %}               
                 <div class="col-sm-6 col-md-4 ">
                     <a {% unless event.url == null %} href="{{event.url}}" {% endunless %} target="_blank" class="event-url">


### PR DESCRIPTION
## Description
Sorting the events from closer to further away. This reverts PR #4; now, by default, the site displays only future events.

## Related Issues
None

## Some questions
- [X] I read the contributing guidelines
- [ ] I'm adding a new event/footer link
- [ ] I'm editing an existing event/footer link
- [X] I'm adding a new feature/fixing a bug
